### PR TITLE
Fix: Correct Webpack entry point for popup

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -7,7 +7,7 @@ const config: import('webpack').Configuration = {
   devtool: 'source-map',
   mode: 'development', // Force development mode to disable minification
   entry: {
-    popup: path.join(__dirname, '/src/popup/simple-index.tsx'),
+    popup: path.join(__dirname, '/src/popup/index.tsx'),
     options: path.join(__dirname, '/src/options/index.tsx'),
     background: path.join(__dirname, '/src/background/index.ts'),
   },


### PR DESCRIPTION
The popup was failing to load due to an incorrect Webpack entry point configuration. `webpack.config.ts` was pointing to `src/popup/simple-index.tsx` instead of `src/popup/index.tsx`.

`simple-index.tsx` is a simplified entry point that does not include necessary providers (like Redux Provider and ThemeProvider) which are set up in `index.tsx` and are potentially required by components within the `UnifiedPopup` structure.

This commit corrects the Webpack entry point for the 'popup' chunk to `src/popup/index.tsx`, ensuring that the main popup bundle is generated with all required context providers, resolving the loading failure.